### PR TITLE
Buildfix

### DIFF
--- a/.config/rules.mk
+++ b/.config/rules.mk
@@ -156,9 +156,9 @@ endif
 
 ifeq ($(origin CFLAGS),undefined)
 ifeq ($(origin DEBUG),undefined)
-CFLAGS = -O2 -Wall -Werror
+CFLAGS = -O2 -Wall
 else
-CFLAGS = -O0 -Wall -Werror
+CFLAGS = -O0 -Wall
 endif
 endif
 ifneq ($(origin DEBUG),undefined)

--- a/.config/rules.mk
+++ b/.config/rules.mk
@@ -111,7 +111,8 @@ override Q :=
 else
 override Q := @
 MAKEFLAGS += --no-print-directory
-out := 2>/dev/null 1>/dev/null
+#out := 2>/dev/null 1>/dev/null
+out := 
 endif
 summary = @echo " $(1)" $(subst $(STARTDIR)/,,$(CURDIR)/)$(2)
 summary2 = @printf " %-5s %s\n" "$(1)" "$(2)"

--- a/panel/gtkbgbox.c
+++ b/panel/gtkbgbox.c
@@ -34,8 +34,6 @@
 #include <glib.h>
 #include <glib-object.h>
 
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations" // FIXME: temporary solution, we need update this code
-
 //#define DEBUGPRN
 #include "dbg.h"
 

--- a/panel/gtkbgbox.c
+++ b/panel/gtkbgbox.c
@@ -34,6 +34,7 @@
 #include <glib.h>
 #include <glib-object.h>
 
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations" // FIXME: temporary solution, we need update this code
 
 //#define DEBUGPRN
 #include "dbg.h"

--- a/panel/plugin.c
+++ b/panel/plugin.c
@@ -18,6 +18,7 @@
 #include "dbg.h"
 extern panel *the_panel;
 
+struct _plugin_instance *stam;
 
 /**************************************************************/
 static GHashTable *class_ht;

--- a/panel/plugin.h
+++ b/panel/plugin.h
@@ -9,7 +9,7 @@
 #include <stdio.h>
 #include "panel.h"
 
-struct _plugin_instance *stam;
+extern struct _plugin_instance *stam;
 
 typedef struct {
     /* common */

--- a/plugins/deskno/deskno.c
+++ b/plugins/deskno/deskno.c
@@ -53,7 +53,7 @@ scrolled(GtkWidget *widget, GdkEventScroll *event, deskno_priv *dc)
 static gint
 name_update(GtkWidget *widget, deskno_priv *dc)
 {
-    char buffer [15];
+    char buffer [19];
 
     ENTER;
     dc->deskno = get_net_current_desktop();


### PR DESCRIPTION
Build should work OK on Debian Bullseye. To build run:
```
./configure
make clean
make
```
~~make system on this project use quite compilation (all gcc output to /dev/null), so in case of problems use `make --trace` and manual call last gcc command to see errors ...~~ - changed in [1717259](https://github.com/fbpanel/fbpanel/pull/7/commits/1717259a7a0d8e3858601c2d066e81d5352a9231) now errors are shown ...